### PR TITLE
feat: add gnome 43 support

### DIFF
--- a/src/metadata.json.in
+++ b/src/metadata.json.in
@@ -9,7 +9,8 @@
     "3.38",
     "40",
     "41",
-    "42"
+    "42",
+    "43"
   ],
   "url": "https://github.com/F-i-f/tweaks-system-menu",
   "uuid": "@uuid@",


### PR DESCRIPTION
A simple addition to add support for Gnome 43.